### PR TITLE
do not fail if /etc/resolv.conf does not exist at all

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,28 @@
 ---
 # fix_empty_etc_resolv_conf/tasks/main.yml
 
+- name: "Check if /etc/resolv.conf exists"
+  stat:
+    path: '/etc/resolv.conf'
+  register: 'stat_etc_resolv_conf'
+
 - name: "Check resolv.conf for wrong entries"
   command: "cat /etc/resolv.conf"
   register: cat_resolv_conf
   check_mode: false
   changed_when: false
+  when: 'stat_etc_resolv_conf.stat.exists == true'
 
 - name: "Remove empty /etc/resolv.conf"
   file:
     path: "/etc/resolv.conf"
     state: "absent"
-  when: cat_resolv_conf.stdout.find("; Created by cloud-init on instance boot automatically, do not edit.") != -1
+  when: 'stat_etc_resolv_conf.stat.exists == true and cat_resolv_conf.stdout.find("; Created by cloud-init on instance boot automatically, do not edit.") != -1'
   notify:
     - "restart network service"
+
+- name: "restart network.service if file was not existing in the beginning"
+  service:
+    name: 'network.service'
+    state: 'restarted'
+  when: 'stat_etc_resolv_conf.stat.exists == false'


### PR DESCRIPTION
do not fail if /etc/resolv.conf does not exist at all, rather trigger a restart of the network.service in this case